### PR TITLE
Fix Makefile linking error and remove unused hashmap.h include

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ CC := gcc
 CFLAGS := -g -fPIC -Wall -Wextra
 SRC_DIR := src
 HEADER_DIR := include
-LIBS := hashmap raylib pthread
+LIBS := raylib pthread m dl
 FILE_NAMES := $(wildcard $(SRC_DIR)/*.c)
 FILE_NAMES := $(foreach word, $(FILE_NAMES), $(patsubst $(SRC_DIR)/%.c,%,$(word)))
 OBJ_DIR := build/lib
@@ -12,7 +12,7 @@ TEST_DIR := tests
 TEST_FILES := $(wildcard $(TEST_DIR)/*.c)
 TEST_FILES := $(foreach word, $(TEST_FILES), $(patsubst $(TEST_DIR)/%.c,%,$(word)))
 BUILD_DIR := build
-INCLUDE_LIBS := $(foreach word, $(LIBS),-l$(word))
+INCLUDE_LIBS := -lraylib -lpthread -lm -ldl
 
 all: build_dir $(FILE_NAMES) main
 

--- a/main.c
+++ b/main.c
@@ -3,7 +3,6 @@
 #include "enviroment.h"
 #include "player.h"
 #include <raylib.h>
-#include <hashmap.h>
 #include <pthread.h>
 
 //------------------------------------------------------------------------------------


### PR DESCRIPTION
### Summary

This PR fixes two build-related issues:

1. **Removes an unused include:**  
   The `#include <hashmap.h>` in `main.c` was unused and caused a build error due to the missing header. It has been safely removed.

2. **Fixes static linking errors with raylib:**  
   When linking against `libraylib.a`, math and dynamic linker symbols (`sqrtf`, `atan2f`, `dlopen`, etc.) were undefined.  
   This is resolved by adding `-lm -ldl` to the `LIBS` in the Makefile.

### Result

- Project now compiles successfully on Linux when using a static raylib build
- No functionality was changed — only build stability improved
